### PR TITLE
Change order of add and remove

### DIFF
--- a/packages/aurelia-gridstack/src/elements/grid-stack/grid-stack.ts
+++ b/packages/aurelia-gridstack/src/elements/grid-stack/grid-stack.ts
@@ -57,7 +57,6 @@ export class GridStack {
         this.updateNodeVmAttributes(x.gridstackNode);
       }
     });
-
   }
 
   attached() {

--- a/packages/aurelia-gridstack/src/elements/grid-stack/grid-stack.ts
+++ b/packages/aurelia-gridstack/src/elements/grid-stack/grid-stack.ts
@@ -48,6 +48,8 @@ export class GridStack {
     if (!this.grid || !this.items) {
       return;
     }
+    const removed = this.grid.engine.nodes.filter(x => !this.items.find(y => y.root === x.el));
+    removed.forEach(x => this.grid.engine.removeNode(x, false, false));
     const newItems = this.items.map(x => x.root).filter(x => !x.gridstackNode);
     newItems.forEach(x => {
       this.grid.addWidget(x);
@@ -55,8 +57,7 @@ export class GridStack {
         this.updateNodeVmAttributes(x.gridstackNode);
       }
     });
-    const removed = this.grid.engine.nodes.filter(x => !this.items.find(y => y.root === x.el));
-    removed.forEach(x => this.grid.engine.removeNode(x, false, false));
+
   }
 
   attached() {


### PR DESCRIPTION
If, for instance, all items are replaced with a new set of items, right now, the old items are still registered with the engine and will block the new items, causing them to be rearranged for no apparent reason. By switching the order, of removeNode and addWidget, you avoid this.